### PR TITLE
商品削除エンドポイントの実装

### DIFF
--- a/backend/app/Constants/MessageConst.php
+++ b/backend/app/Constants/MessageConst.php
@@ -9,6 +9,7 @@ class MessageConst
     public const PLAN_NOT_SUBSCRIBED = 'ご契約中のプランが見つかりません';
     public const PLAN_LIMIT_TABLE_COUNT_EXCEEDED = 'ご契約のプランのテーブル数上限（:limit）を超えています';
     public const UPLOAD_FILE_FAILED = 'ファイルのアップロードに失敗しました';
+    public const ITEM_NOT_FOUND = '商品が見つかりません';
 
     public static function generateMessage(string $message, array $params = []): string
     {

--- a/backend/app/Http/Controllers/TenantController.php
+++ b/backend/app/Http/Controllers/TenantController.php
@@ -8,7 +8,9 @@ use App\Http\Requests\UpdateItemRequest;
 use App\Http\Resources\ItemResource;
 use App\Usecases\Tenant\ChangeTableCountAction;
 use App\Usecases\Tenant\CreateItemAction;
+use App\Usecases\Tenant\DeleteItemAction;
 use App\Usecases\Tenant\UpdateItemAction;
+use Illuminate\Http\Request;
 
 class TenantController extends Controller
 {
@@ -32,5 +34,11 @@ class TenantController extends Controller
         $image = $request->file('image');
 
         return new ItemResource($action($tenant, $itemID, $newItem, $image));
+    }
+
+    public function deleteItem(Request $request, DeleteItemAction $action): void {
+        $tenant = $request->user()->tenant;
+        $itemID = $request->route('id');
+        $action($tenant, $itemID);
     }
 }

--- a/backend/app/Usecases/Tenant/DeleteItemAction.php
+++ b/backend/app/Usecases/Tenant/DeleteItemAction.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Usecases\Tenant;
+
+use App\Constants\MessageConst;
+use App\Models\Item;
+use App\Models\Tenant;
+use App\Usecases\Tenant\Exceptions\ItemNotFoundException;
+
+class DeleteItemAction
+{
+    public function __invoke(Tenant $tenant, int $itemID): void
+    {
+        $item = Item::where('tenant_id', $tenant->id)
+            ->where('id', $itemID)
+            ->first();
+        
+        if($item === null) {
+            throw new ItemNotFoundException(MessageConst::ITEM_NOT_FOUND);
+        }
+
+        $item->delete();
+    }
+}

--- a/backend/app/Usecases/Tenant/Exceptions/ItemNotFoundException.php
+++ b/backend/app/Usecases/Tenant/Exceptions/ItemNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Usecases\Tenant\Exceptions;
+
+use Exception;
+use Illuminate\Http\Response;
+
+class ItemNotFoundException extends Exception
+{
+    public function render($request)
+    {
+        return response()->json([
+            'message' => $this->getMessage(),
+        ], Response::HTTP_NOT_FOUND);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -16,5 +16,6 @@ Route::middleware('auth:sanctum')->group(function() {
         Route::put('/tables', [TenantController::class, 'changeTableCount']);
         Route::post('/items', [TenantController::class, 'createItem']);
         Route::patch('/items/{id}', [TenantController::class, 'updateItem']);
+        Route::delete('/items/{id}', [TenantController::class, 'deleteItem']);
     });
 });

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -148,6 +148,25 @@ paths:
                   message:
                     type: string
                     example: "ファイルのアップロードに失敗しました"
+    delete:
+      summary: "delete item"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: "OK"
+        '401':
+          description: "Unauthorized"
+        '404':
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
 components:
   schemas:


### PR DESCRIPTION
## チケットへのリンク

* https://www.notion.so/yumemi/CRUD-36152c47c92b474fbdb084ba458a1f4b?pvs=4

## やったこと

* 商品の削除を実装しました
* 会計情報がなくならないように論理削除にしています

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 登録した商品の削除

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 正しく論理削除されること
* 他テナントの商品が削除できないこと

## その他

* 他テナントの商品でないかの確認はRequest.php内のauthorize()で行った方がいいでしょうか？