### PR TITLE
feature: 商品一覧取得機能の実装

### DIFF
--- a/backend/app/Http/Controllers/ItemController.php
+++ b/backend/app/Http/Controllers/ItemController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\ItemResource;
+use App\Usecases\Tenant\ListItemAction;
+use Illuminate\Http\Request;
+
+final class ItemController extends Controller
+{
+    public function listItems(Request $request, ListItemAction $action): array
+    {
+        $tenantID = $request->query('tenant_id');
+        $items = $action($tenantID);
+
+        $resources = [];
+        foreach ($items as $item) {
+            $itemResource = new ItemResource($item);
+            $resources[] = $itemResource;
+        }
+        return $resources;
+    }
+}

--- a/backend/app/Http/Middleware/EnsureJWTIsValid.php
+++ b/backend/app/Http/Middleware/EnsureJWTIsValid.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Exception;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+final class EnsureJWTIsValid
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response) $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = $request->query('token');
+        if($token === null) {
+            return response()->json(['message' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
+        }
+        
+        try {
+            $decoded = JWT::decode($token, new Key(config('jwt.secret'), 'HS256'));
+            $decodedArray = (array) $decoded;
+            $request->merge($decodedArray);
+        } catch (Exception $e) {
+            Log::error($e->getMessage());
+            return response()->json(['message' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Resources/ItemResource.php
+++ b/backend/app/Http/Resources/ItemResource.php
@@ -5,16 +5,23 @@ declare(strict_types=1);
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
 
 final class ItemResource extends JsonResource
 {
     public function toArray($request): array
     {
+        /**
+         * @var \Illuminate\Filesystem\FilesystemAdapter $disk
+         */
+        $disk = Storage::disk('s3');
+        $imageUrl = $disk->url($this->s3_key);
+
         return [
             'id' => $this->id,
             'name' => $this->name,
             'description' => $this->description,
-            's3_key' => $this->s3_key,
+            'image_url' => $imageUrl,
             'cost_price' => $this->cost_price,
             'tax_rate_id' => $this->tax_rate_id,
             'created_at' => $this->created_at,

--- a/backend/app/Usecases/Tenant/ListItemAction.php
+++ b/backend/app/Usecases/Tenant/ListItemAction.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Usecases\Tenant;
+
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Collection;
+
+final class ListItemAction
+{
+    public function __invoke(int $tenantID): Collection
+    {
+        $items = Tenant::find($tenantID)->items;
+        return $items;
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,17 +3,20 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Auth\AuthController;
+use App\Http\Controllers\ItemController;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\TenantController;
-use Illuminate\Http\Request;
+use App\Http\Middleware\EnsureJWTIsValid;
 use Illuminate\Support\Facades\Route;
-
-Route::get('/user', static function (Request $request) {
-    return $request->user();
-})->middleware('auth:sanctum');
 
 Route::post('/login', [AuthController::class, 'login']);
 
+// JWTトークンが必要なAPI
+Route::middleware(EnsureJWTIsValid::class)->group(static function () {
+    Route::get('/items', [ItemController::class, 'listItems']);
+});
+
+// ログイン認証が必要なAPI
 Route::middleware('auth:sanctum')->group(static function() {
     Route::group(['prefix' => '/setting'], static function() {
         Route::put('/tables', [TenantController::class, 'changeTableCount']);


### PR DESCRIPTION
## チケットへのリンク

* https://www.notion.so/yumemi/JWT-6aa0db87610d4e6784689840e3d51995?pvs=4

## やったこと

* 商品一覧取得のエンドポイントの実装
* クエリパラメータに付与されたJWTトークンの検証を行うミドルウェアの実装
* ItemResourceの改修(urlを直接返すように変更)

## やらないこと

* なし
## できるようになること（ユーザ目線）

* お客様が商品一覧を取得できるようになる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 発行したJWTをクエリにつけてリクエストをすることで商品一覧を取得できる
* 不正なJWTを弾く

## その他
* GitHubActionsがエラーを出しているので、一旦手動でフォーマットをかけています