### PR TITLE
Feature/get table order

### DIFF
--- a/backend/app/Http/Controllers/OrderController.php
+++ b/backend/app/Http/Controllers/OrderController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers;
 use App\Http\Requests\Order\InitOrderRequest;
 use App\Http\Requests\TakeOrderItemRequest;
 use App\Http\Resources\OrderItemResource;
+use App\Usecases\Order\GetTableOrderItemsAction;
 use App\Usecases\Order\InitOrderAction;
 use App\Usecases\Order\TakeOrderItemAction;
+use Illuminate\Http\Request;
 
 final class OrderController extends Controller
 {
@@ -24,6 +26,19 @@ final class OrderController extends Controller
         $orderItems = $request->makeOrderItems();
 
         $orderItems = $action($tenantID, $orderID, $orderItems);
+
+        $resources = [];
+        foreach ($orderItems as $orderItem) {
+            $resources[] = new OrderItemResource($orderItem);
+        }
+        return $resources;
+    }
+
+    public function getTableOrderItems(Request $request, GetTableOrderItemsAction $action): array {
+        $tenant = $request->user()->tenant;
+        $orderID = $request->route('id');
+
+        $orderItems = $action($tenant, intval($orderID));
 
         $resources = [];
         foreach ($orderItems as $orderItem) {

--- a/backend/app/Http/Controllers/OrderController.php
+++ b/backend/app/Http/Controllers/OrderController.php
@@ -48,16 +48,13 @@ final class OrderController extends Controller
         $tableNumber = $request->query('table_number') ? (int) ($request->query('table_number')) : null;
 
         if($orderID !== null) {
-            $order = $getOrderByIDAction($tenant, $orderID);
-            return new OrderResource($order);
-        }
-        
-        if($tableNumber !== null) {
-            $order = $getOpenOrderByTableNumberAction($tenant, $tableNumber);
-            return new OrderResource($order);
+            $orders = $getOrderByIDAction($tenant, $orderID);
+        } elseif($tableNumber !== null) {
+            $orders = $getOpenOrderByTableNumberAction($tenant, $tableNumber);
+        } else {
+            $orders = $getOpenOrdersAllAction($tenant);
         }
 
-        $orders = $getOpenOrdersAllAction($tenant);
         $resources = [];
         foreach ($orders as $order) {
             $resources[] = new OrderResource($order);

--- a/backend/app/Http/Resources/OrderResource.php
+++ b/backend/app/Http/Resources/OrderResource.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class OrderResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'tenant_id' => $this->tenant_id,
+            'table_number' => $this->table_number,
+            'status' => $this->status,
+            'total_price' => $this->total_price,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+            'order_items' => OrderItemResource::collection($this->order_items),
+        ];
+    }
+}

--- a/backend/app/Usecases/Order/GetOpenOrderByTableNumberAction.php
+++ b/backend/app/Usecases/Order/GetOpenOrderByTableNumberAction.php
@@ -11,7 +11,7 @@ use App\Usecases\Order\Exceptions\OrderNotFoundException;
 
 final class GetOpenOrderByTableNumberAction
 {
-    public function __invoke(Tenant $tenant, int $tableNumber): Order
+    public function __invoke(Tenant $tenant, int $tableNumber): array
     {
         $order = Order::where('tenant_id', $tenant->id)
             ->where('table_number', $tableNumber)
@@ -22,6 +22,6 @@ final class GetOpenOrderByTableNumberAction
             throw new OrderNotFoundException(MessageConst::ORDER_NOT_FOUND);
         }
 
-        return $order;
+        return [$order];
     }
 }

--- a/backend/app/Usecases/Order/GetOpenOrderByTableNumberAction.php
+++ b/backend/app/Usecases/Order/GetOpenOrderByTableNumberAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Usecases\Order;
+
+use App\Constants\MessageConst;
+use App\Models\Order;
+use App\Models\Tenant;
+use App\Usecases\Order\Exceptions\OrderNotFoundException;
+
+final class GetOpenOrderByTableNumberAction
+{
+    public function __invoke(Tenant $tenant, int $tableNumber): Order
+    {
+        $order = Order::where('tenant_id', $tenant->id)
+            ->where('table_number', $tableNumber)
+            ->where('status', Order::STATUS_OPEN)
+            ->first();
+        
+        if ($order === null) {
+            throw new OrderNotFoundException(MessageConst::ORDER_NOT_FOUND);
+        }
+
+        return $order;
+    }
+}

--- a/backend/app/Usecases/Order/GetOpenOrdersAllAction.php
+++ b/backend/app/Usecases/Order/GetOpenOrdersAllAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Usecases\Order;
+
+use App\Constants\MessageConst;
+use App\Models\Order;
+use App\Models\Tenant;
+use App\Usecases\Order\Exceptions\OrderNotFoundException;
+use Illuminate\Database\Eloquent\Collection;
+
+final class GetOpenOrdersAllAction
+{
+    public function __invoke(Tenant $tenant): Collection
+    {
+        $orders = Order::where('tenant_id', $tenant->id)
+            ->where('status', Order::STATUS_OPEN)
+            ->get();
+        
+        if ($orders === null) {
+            throw new OrderNotFoundException(MessageConst::ORDER_NOT_FOUND);
+        }
+
+        return $orders;
+    }
+}

--- a/backend/app/Usecases/Order/GetOrderByIDAction.php
+++ b/backend/app/Usecases/Order/GetOrderByIDAction.php
@@ -8,11 +8,10 @@ use App\Constants\MessageConst;
 use App\Models\Order;
 use App\Models\Tenant;
 use App\Usecases\Order\Exceptions\OrderNotFoundException;
-use Illuminate\Database\Eloquent\Collection;
 
-final class GetTableOrderItemsAction
+final class GetOrderByIDAction
 {
-    public function __invoke(Tenant $tenant, int $orderID): Collection
+    public function __invoke(Tenant $tenant, int $orderID): Order
     {
         $order = Order::where('tenant_id', $tenant->id)
             ->where('id', $orderID)
@@ -22,6 +21,6 @@ final class GetTableOrderItemsAction
             throw new OrderNotFoundException(MessageConst::ORDER_NOT_FOUND);
         }
 
-        return $order->order_items;
+        return $order;
     }
 }

--- a/backend/app/Usecases/Order/GetOrderByIDAction.php
+++ b/backend/app/Usecases/Order/GetOrderByIDAction.php
@@ -11,7 +11,7 @@ use App\Usecases\Order\Exceptions\OrderNotFoundException;
 
 final class GetOrderByIDAction
 {
-    public function __invoke(Tenant $tenant, int $orderID): Order
+    public function __invoke(Tenant $tenant, int $orderID): array
     {
         $order = Order::where('tenant_id', $tenant->id)
             ->where('id', $orderID)
@@ -21,6 +21,6 @@ final class GetOrderByIDAction
             throw new OrderNotFoundException(MessageConst::ORDER_NOT_FOUND);
         }
 
-        return $order;
+        return [$order];
     }
 }

--- a/backend/app/Usecases/Order/GetTableOrderItemsAction.php
+++ b/backend/app/Usecases/Order/GetTableOrderItemsAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Usecases\Order;
+
+use App\Constants\MessageConst;
+use App\Models\Order;
+use App\Models\Tenant;
+use App\Usecases\Order\Exceptions\OrderNotFoundException;
+use Illuminate\Database\Eloquent\Collection;
+
+final class GetTableOrderItemsAction
+{
+    public function __invoke(Tenant $tenant, int $orderID): Collection
+    {
+        $order = Order::where('tenant_id', $tenant->id)
+            ->where('id', $orderID)
+            ->first();
+        
+        if ($order === null) {
+            throw new OrderNotFoundException(MessageConst::ORDER_NOT_FOUND);
+        }
+
+        return $order->order_items;
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -28,5 +28,6 @@ Route::middleware('auth:sanctum')->group(static function() {
 
     Route::group(['prefix' => '/orders'], static function() {
         Route::post('', [OrderController::class, 'initializeOrder']);
+        Route::get('/{id}', [OrderController::class, 'getTableOrderItems']);
     });
 });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -28,6 +28,6 @@ Route::middleware('auth:sanctum')->group(static function() {
 
     Route::group(['prefix' => '/orders'], static function() {
         Route::post('', [OrderController::class, 'initializeOrder']);
-        Route::get('/{id}', [OrderController::class, 'getTableOrderItems']);
+        Route::get('', [OrderController::class, 'getTableOrderItems']);
     });
 });

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -168,6 +168,41 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   /orders:
+    get:
+      summary: "get orders"
+      description: "クエリパラメータでの指定がなければ現在未会計のオーダーを全て返します"
+      parameters:
+        - name: table_number
+          in: query
+          schema:
+            type: string
+          description: "return open order for table number"
+        - name: order_id
+          in: query
+          schema:
+            type: string
+          description: "return order by order id"
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Order"
+        '401':
+          description: "Unauthorized"
+        '500':
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Internal Server Error"
     post:
       summary: "initialize order"
       requestBody:
@@ -303,6 +338,10 @@ components:
           type: integer
         status:
           type: string
+        order_items:
+          type: array
+          items:
+            $ref: "#/components/schemas/OrderItem"
     
     OrderItem:
       type: object


### PR DESCRIPTION
## チケットへのリンク

* https://www.notion.so/yumemi/7576816599874384a2b1e6c19deab640?pvs=4
* https://www.notion.so/yumemi/9f1479fb7bd4439cb4ca24788558792c?pvs=4

## やったこと

* テーブル注文状況一覧エンドポイントの実装
* テーブル注文状況詳細エンドポイントの実装

## やらないこと

* テストの実装

## できるようになること（ユーザ目線）

* 注文状況が一覧で取得できる
* あるテーブルの注文状況が取得できる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* APIが正しいレスポンスを返す

## その他

* 現在未会計のオーダーを全て返す処理と、オーダーIDやテーブル番号で指定されてオーダーを返す処理を同じエンドポイントで実装してみました。ただ、クエリパラメータの使い方がパッとしない( オーダーIDでの指定は/orders/{id}のようなAPIにした方がいい？)のでご意見いただきたいです。
* また、エンドポイントが配列かオブジェクト単体で分岐するよりはオブジェクトを配列でラップして型を一定にしたほうがフロントで扱いやすいかな？と思って実装してますが、これも意見いただきたいです。みなさんはどっち派でしょうか？