### PR TITLE
feat: 会計処理エンドポイントの実装

### DIFF
--- a/backend/app/Constants/MessageConst.php
+++ b/backend/app/Constants/MessageConst.php
@@ -14,6 +14,8 @@ final class MessageConst
     public const ACTIVE_ORDER_ALREADY_EXIST = '既にオーダーが存在しています';
     public const ORDER_NOT_FOUND = 'オーダーが見つかりません';
     public const ORDER_ITEM_NOT_FOUND = 'オーダーアイテムが見つかりません';
+    public const ORDER_ALREADY_PAID = 'オーダーは既に支払済みです';
+    public const PENDING_ITEMS_EXIST = '未提供の商品が存在します';
 
     public static function generateMessage(string $message, array $params = []): string
     {

--- a/backend/app/Http/Controllers/OrderController.php
+++ b/backend/app/Http/Controllers/OrderController.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Order\CheckOutRequest;
 use App\Http\Requests\Order\InitOrderRequest;
 use App\Http\Requests\Order\UpdateOrderItemRequest;
 use App\Http\Requests\TakeOrderItemRequest;
 use App\Http\Resources\OrderItemResource;
 use App\Http\Resources\OrderResource;
+use App\Usecases\Order\CheckoutAction;
+use App\Usecases\Order\GetCheckoutAction;
 use App\Usecases\Order\GetOpenOrderByTableNumberAction;
 use App\Usecases\Order\GetOpenOrdersAllAction;
 use App\Usecases\Order\GetOrderByIDAction;
@@ -16,6 +19,7 @@ use App\Usecases\Order\InitOrderAction;
 use App\Usecases\Order\TakeOrderItemAction;
 use App\Usecases\Order\UpdateOrderItemAction;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 final class OrderController extends Controller
 {
@@ -74,5 +78,34 @@ final class OrderController extends Controller
 
         $orderItem = $action($tenant, $orderID, $orderItemID, $request->makeOrderItem());
         return new OrderItemResource($orderItem);
+    }
+
+    public function getCheckout(
+        Request $request,
+        GetCheckoutAction $getCheckoutAction
+    ): array {
+        // JWTトークンの中にテナントIDが入っている
+        $tenantID = $request->input('tenant_id');
+        $orderID = $request->input('order_id');
+
+        // ログインユーザーのテナントを取得
+        $tenant = $request->user()->tenant;
+        if ($tenant->id !== $tenantID) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+
+        $result = $getCheckoutAction($tenant, $orderID);
+        return [
+            'order' => new OrderResource($result['order']),
+            'pendingItems' => $result['pendingItems'],
+        ];
+    }
+
+    public function checkout(CheckOutRequest $request, CheckoutAction $action): OrderResource {
+        $tenant = $request->user()->tenant;
+        $orderID = $request->order_id;
+
+        $order = $action($tenant, $orderID);
+        return new OrderResource($order);
     }
 }

--- a/backend/app/Http/Controllers/TenantController.php
+++ b/backend/app/Http/Controllers/TenantController.php
@@ -14,7 +14,6 @@ use App\Usecases\Tenant\ChangeTableCountAction;
 use App\Usecases\Tenant\CreateItemAction;
 use App\Usecases\Tenant\DeleteItemAction;
 use App\Usecases\Tenant\UpdateItemAction;
-use Exception;
 use Illuminate\Http\Request;
 
 final class TenantController extends Controller

--- a/backend/app/Http/Requests/Order/CheckOutRequest.php
+++ b/backend/app/Http/Requests/Order/CheckOutRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Order;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CheckOutRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'order_id' => ['required', 'integer'],
+        ];
+    }
+}

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -26,6 +26,19 @@ final class Order extends Model
         'total_price' => 'integer',
     ];
 
+    public function update_total_price(): void
+    {
+        $total_price = 0;
+        foreach ($this->order_items as $order_item) {
+            if ($order_item->status === OrderItem::STATUS_CANCELLED) {
+                continue;
+            }
+            $total_price += $order_item->sub_total;
+        }
+        $this->total_price = $total_price;
+        $this->save();
+    }
+
     public function tenant()
     {
         return $this->belongsTo(Tenant::class);

--- a/backend/app/Usecases/Order/CheckOutAction.php
+++ b/backend/app/Usecases/Order/CheckOutAction.php
@@ -11,8 +11,9 @@ use App\Models\Tenant;
 use App\Usecases\Order\Exceptions\OrderAlreadyPaidException;
 use App\Usecases\Order\Exceptions\OrderNotFoundException;
 use App\Usecases\Order\Exceptions\PendingItemsExistException;
+use function count;
 
-final class CheckoutAction
+final class CheckOutAction
 {
     public function __invoke(Tenant $tenant, int $orderID): Order
     {

--- a/backend/app/Usecases/Order/CheckOutAction.php
+++ b/backend/app/Usecases/Order/CheckOutAction.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Usecases\Order;
+
+use App\Constants\MessageConst;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Tenant;
+use App\Usecases\Order\Exceptions\OrderAlreadyPaidException;
+use App\Usecases\Order\Exceptions\OrderNotFoundException;
+use App\Usecases\Order\Exceptions\PendingItemsExistException;
+
+final class CheckoutAction
+{
+    public function __invoke(Tenant $tenant, int $orderID): Order
+    {
+        $order = Order::where('tenant_id', $tenant->id)
+            ->where('id', $orderID)
+            ->first();
+        if ($order === null) {
+            throw new OrderNotFoundException(MessageConst::ORDER_NOT_FOUND);
+        }
+        if ($order->status === Order::STATUS_PAID) {
+            throw new OrderAlreadyPaidException(MessageConst::ORDER_ALREADY_PAID);
+        }
+
+        // 未提供の商品があるかどうかをチェック
+        $pendingItems = [];
+        foreach ($order->order_items as $orderItem) {
+            if ($orderItem->status === OrderItem::STATUS_PENDING) {
+                $pendingItems[] = $orderItem;
+            }
+        }
+        if (count($pendingItems) > 0) {
+            throw new PendingItemsExistException(MessageConst::PENDING_ITEMS_EXIST, $pendingItems);
+        }
+
+        // オーダーを会計済みに変更
+        $order->status = Order::STATUS_PAID;
+        $order->save();
+
+        return $order;
+    }
+}

--- a/backend/app/Usecases/Order/Exceptions/OrderAlreadyPaidException.php
+++ b/backend/app/Usecases/Order/Exceptions/OrderAlreadyPaidException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Usecases\Order\Exceptions;
+
+use Exception;
+use Illuminate\Http\Response;
+
+final class OrderAlreadyPaidException extends Exception
+{
+    public function render($request)
+    {
+        return response()->json([
+            'message' => $this->getMessage(),
+        ], Response::HTTP_BAD_REQUEST);
+    }
+}

--- a/backend/app/Usecases/Order/Exceptions/PendingItemsExistException.php
+++ b/backend/app/Usecases/Order/Exceptions/PendingItemsExistException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Usecases\Order\Exceptions;
+
+use App\Http\Resources\OrderItemResource;
+use Exception;
+use Illuminate\Http\Response;
+
+final class PendingItemsExistException extends Exception
+{
+    private array $pendingItems;
+
+    public function __construct(string $message, array $pendingItems)
+    {
+        parent::__construct($message);
+        $this->pendingItems = $pendingItems;
+    }
+
+    public function render($request)
+    {
+        return response()->json([
+            'message' => $this->getMessage(),
+            'pending_items' => OrderItemResource::collection($this->pendingItems),
+        ], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/backend/app/Usecases/Order/GetCheckoutAction.php
+++ b/backend/app/Usecases/Order/GetCheckoutAction.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Usecases\Order;
+
+use App\Constants\MessageConst;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Tenant;
+use App\Usecases\Order\Exceptions\OrderAlreadyPaidException;
+use App\Usecases\Order\Exceptions\OrderNotFoundException;
+
+final class GetCheckoutAction
+{
+    public function __invoke(Tenant $tenant, int $orderID): array
+    {
+        $order = Order::where('tenant_id', $tenant->id)
+            ->where('id', $orderID)
+            ->first();
+        if ($order === null) {
+            throw new OrderNotFoundException(MessageConst::ORDER_NOT_FOUND);
+        }
+        if ($order->status === Order::STATUS_PAID) {
+            throw new OrderAlreadyPaidException(MessageConst::ORDER_ALREADY_PAID);
+        }
+
+        // 未提供の商品があるかどうかをチェック
+        $pendingItems = [];
+        foreach ($order->order_items as $orderItem) {
+            if ($orderItem->status === OrderItem::STATUS_PENDING) {
+                $pendingItems[] = $orderItem;
+            }
+        }
+
+        return [
+            'order' => $order,
+            'pendingItems' => $pendingItems,
+        ];
+    }
+}

--- a/backend/app/Usecases/Order/TakeOrderItemAction.php
+++ b/backend/app/Usecases/Order/TakeOrderItemAction.php
@@ -46,8 +46,7 @@ final class TakeOrderItemAction
                 $orderItem->save();
             }
 
-            $order->total_price = $order->order_items->sum('sub_total');
-            $order->save();
+            $order->update_total_price();
             DB::commit();
             return $orderItems;
         } catch (Exception $e) {

--- a/backend/app/Usecases/Order/UpdateOrderItemAction.php
+++ b/backend/app/Usecases/Order/UpdateOrderItemAction.php
@@ -30,13 +30,10 @@ final class UpdateOrderItemAction
                 $orderItem->quantity = $newOrderItem->quantity;
                 $orderItem->sub_total = $orderItem->item->cost_price * $newOrderItem->quantity * $orderItem->tax_rate;
                 $orderItem->save();
-    
-                $order = $orderItem->order;
-                $order->total_price = $order->order_items->sum('sub_total');
-                $order->save();
             }
-    
+
             $orderItem->update($newOrderItem->toArray());
+            $orderItem->order->update_total_price();
             DB::commit();
             return $orderItem;
         } catch (Exception $e) {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -31,4 +31,10 @@ Route::middleware('auth:sanctum')->group(static function() {
         Route::get('', [OrderController::class, 'getTableOrderItems']);
         Route::put('/{order_id}/items/{order_item_id}', [OrderController::class, 'updateOrderItem']);
     });
+    Route::post('/checkout', [OrderController::class, 'checkout']);
+});
+
+// JWTトークンとログイン認証が必要なAPI
+Route::middleware(['auth:sanctum', EnsureJWTIsValid::class])->group(static function() {
+    Route::get('/checkout', [OrderController::class, 'getCheckout']);
 });

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -245,6 +245,12 @@ paths:
   /items:
     get:
       summary: "get items"
+      parameters:
+        - name: token
+          in: query
+          schema:
+            type: string
+          required: true
       responses:
         '200':
           description: "OK"
@@ -269,6 +275,12 @@ paths:
   /orders/items:
     post:
       summary: "add item to order"
+      parameters:
+        - name: token
+          in: query
+          schema:
+            type: string
+          required: true
       requestBody:
         content:
           application/json:
@@ -332,6 +344,103 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /checkout:
+    get:
+      summary: "get checkout order"
+      parameters:
+        - name: token
+          in: query
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  order:
+                    $ref: "#/components/schemas/Order"
+                  pending_items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Item"
+        '400':
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "会計済みのオーダーです"
+        '401':
+          description: "Unauthorized"
+        '403':
+          description: "Forbidden"
+        '404':
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: "checkout order"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - order_id
+              properties:
+                order_id:
+                  type: integer
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  order:
+                    $ref: "#/components/schemas/Order"
+        '400':
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "会計済みのオーダーです"
+        '401':
+          description: "Unauthorized"
+        '404':
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '422':
+          description: "Unprocessable Entity"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "未提供の商品があります"
+                  pending_items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Item"
 
 components:
   schemas:


### PR DESCRIPTION
## チケットへのリンク

* https://www.notion.so/yumemi/1651f2d7c72443dfbfcd78f17ed1269d?pvs=4

## やったこと

* 会計情報取得エンドポイント実装
* 会計エンドポイント実装
* 注文・注文状況更新エンドポイントに合計金額の更新処理を追加

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 会計情報の取得
* オーダーの会計
## できなくなること（ユーザ目線）

* なし

## 動作確認

* エンドポイントが正常に動作する

## その他
